### PR TITLE
Add force deleted event

### DIFF
--- a/src/SoftDeletesBoolean.php
+++ b/src/SoftDeletesBoolean.php
@@ -37,11 +37,13 @@ trait SoftDeletesBoolean
     {
         $this->forceDeleting = true;
 
-        $deleted = $this->delete();
+        return tap($this->delete(), function ($deleted) {
+            $this->forceDeleting = false;
 
-        $this->forceDeleting = false;
-
-        return $deleted;
+            if ($deleted) {
+                $this->fireModelEvent('forceDeleted', false);
+            }
+        });
     }
 
     /**
@@ -148,6 +150,17 @@ trait SoftDeletesBoolean
     public static function restored($callback)
     {
         static::registerModelEvent('restored', $callback);
+    }
+
+    /**
+     * Register a "forceDeleted" model event callback with the dispatcher.
+     *
+     * @param  \Closure|string  $callback
+     * @return void
+     */
+    public static function forceDeleted($callback)
+    {
+        static::registerModelEvent('forceDeleted', $callback);
     }
 
     /**


### PR DESCRIPTION
## Description

This change adds a `forceDeleted` event.

## Motivation and context

Eloquent has added a `forceDeleted` event to its soft delete implementation. This change adds exactly the same event to the boolean soft-deletes implementation.

You can see that the changes match the Eloquent implementation here:
https://github.com/illuminate/database/blob/aad650ceb4a258ac113e5f9f83fda8c66e9083cf/Eloquent/SoftDeletes.php#L47-L58

## How has this been tested?

Your package does not have any tests for me to update or run to test the changes. However, I am using this package via [laravel-json-api/boolean-softdeletes](https://github.com/laravel-json-api/boolean-softdeletes) which does have acceptance tests covering the deleting and force-deleting models with this trait. Those tests pass with these changes, including checking the new `forceDeleted` event is fired.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

